### PR TITLE
Fixed typo in _followSymlink

### DIFF
--- a/lib/_follow_symlink.js
+++ b/lib/_follow_symlink.js
@@ -17,7 +17,7 @@ async function _followSymlink (filename) {
     let linked = await new Promise((resolve, reject) =>
       fs.readlink(filename, (err, linked) => err ? reject(err) : resolve(linked))
     )
-    linked = path.join(path.dirname(filename, linked))
+    linked = path.join(path.dirname(filename), linked)
     return await _followSymlink(linked)
   }
   return filename


### PR DESCRIPTION
I've discovered a bug related with typo in symlink traversal. I've fixed the type and paths were resolved correctly.